### PR TITLE
Change prop:equal+hash to use Integer

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -55,9 +55,9 @@
       (define/with-syntax ComparerType-Equal
         (maybe-∀2 #'(→ ins ins2 (→ Any Any Boolean) Any)))
       (define/with-syntax ComparerType-Hash1
-        (maybe-∀ #'(→ ins (→ Any Fixnum) Fixnum)))
+        (maybe-∀ #'(→ ins (→ Any Integer) Integer)))
       (define/with-syntax ComparerType-Hash2
-        (maybe-∀ #'(→ ins (→ Any Fixnum) Fixnum)))
+        (maybe-∀ #'(→ ins (→ Any Integer) Integer)))
       (define/with-syntax ComparerType
         #'(List ComparerType-Equal
                 ComparerType-Hash1
@@ -102,10 +102,10 @@
                                         #'(→ ins ins2 (→ Any Any Boolean) Any)))
                                 (ann hash1
                                      #,(maybe-∀
-                                        #'(→ ins (→ Any Fixnum) Fixnum)))
+                                        #'(→ ins (→ Any Integer) Integer)))
                                 (ann hash2
                                      #,(maybe-∀
-                                        #'(→ ins (→ Any Fixnum) Fixnum))))]
+                                        #'(→ ins (→ Any Integer) Integer))))]
                        [expr:expr #'expr]))
                    #`(define eq+h-implementation (λ () equal+hash-ann)))))])))
 


### PR DESCRIPTION
The `prop:equal+hash` property allows `Integer` the result type of the hashing functions. This PR changes the types to use `Integer` instead of `Fixnum`.

This is still well-typed with `equal-hash-code` because when a `prop:equal+hash` function returns an integer that isn't a fixnum, `equal-hash-code` will still return a fixnum.